### PR TITLE
Fix symbol clash after ncurses introduced format attributes.

### DIFF
--- a/gui_ncurses.c
+++ b/gui_ncurses.c
@@ -19,6 +19,9 @@ MOJOGUI_PLUGIN(ncurses)
 CREATE_MOJOGUI_ENTRY_POINT(ncurses)
 #endif
 
+// ncurses headers use 'format' in an __attribute__, undefine ours for now.
+#undef format
+
 #include <unistd.h>
 #include <ctype.h>
 // CMake searches for a whole bunch of different possible curses includes
@@ -35,6 +38,10 @@ CREATE_MOJOGUI_ENTRY_POINT(ncurses)
 #endif
 
 #include <locale.h>
+
+// restore the format define from gui.h now that the ncurses headers are done.
+#define format entry->format
+
 
 // This was built to look roughly like dialog(1), but it's not nearly as
 //  robust. Also, I didn't use any of dialog's code, as it is GPL/LGPL,


### PR DESCRIPTION
If *MOJOSETUP_GUI_NCURSES* is enabled I see the following compile errors:

```
[  1%] Building C object CMakeFiles/mojosetupgui_ncurses.dir/gui_ncurses.c.o
In file included from /home/kratz00/coding/mojosetup/gui_ncurses.c:14:
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
In file included from /home/kratz00/coding/mojosetup/gui_ncurses.c:32:
/usr/include/curses.h:713:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  713 |                 GCC_PRINTFLIKE(3,4);
      |                 ^~~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:715:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  715 |                 GCC_SCANFLIKE(3,4);
      |                 ^~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:738:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  738 |                 GCC_PRINTFLIKE(4,5);
      |                 ^~~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:740:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  740 |                 GCC_SCANFLIKE(4,5);
      |                 ^~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:762:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  762 |                 GCC_PRINTFLIKE(1,2);
      |                 ^~~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:774:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  774 |                 GCC_SCANFLIKE(1,2);
      |                 ^~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:820:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  820 |                 GCC_PRINTFLIKE(2,0);
      |                 ^~~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:822:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  822 |                 GCC_PRINTFLIKE(2,0);
      |                 ^~~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:824:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  824 |                 GCC_SCANFLIKE(2,0);
      |                 ^~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:826:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  826 |                 GCC_SCANFLIKE(2,0);
      |                 ^~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:869:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  869 |                 GCC_PRINTFLIKE(2,3);
      |                 ^~~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:873:17: error: expected ‘,’ or ‘;’ before ‘)’ token
  873 |                 GCC_SCANFLIKE(2,3);
      |                 ^~~~~~~~~~~~~
/home/kratz00/coding/mojosetup/gui.h:249:21: error: expected ‘)’ before ‘->’ token
  249 | #define format entry->format
      |                     ^~
/usr/include/curses.h:2047:57: error: expected ‘,’ or ‘;’ before ‘)’ token
 2047 | extern NCURSES_EXPORT(void) _tracef (const char *, ...) GCC_PRINTFLIKE(1,2);
      |                                                         ^~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/mojosetupgui_ncurses.dir/build.make:76: CMakeFiles/mojosetupgui_ncurses.dir/gui_ncurses.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/mojosetupgui_ncurses.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
