### PR TITLE
Fix warning: pointer 'io' may be used after 'fclose'

### DIFF
--- a/misc/make_self_extracting.c
+++ b/misc/make_self_extracting.c
@@ -75,7 +75,10 @@ static off_t get_file_size(const char *fname)
     else if ((retval = ftello(io)) == -1)
         FAIL("ftello");
     else if (fclose(io) == EOF)
+    {
+        io = NULL;
         FAIL("fclose");
+    } // else if
     #undef FAIL
 
     return retval;


### PR DESCRIPTION
Fix for the following warning:
```

/home/kratz00/coding/mojosetup/misc/make_self_extracting.c: In function 'get_file_size':
/home/kratz00/coding/mojosetup/misc/make_self_extracting.c:66:13: warning: pointer 'io' may be used after 'fclose' [-Wuse-after-free]
   66 |             fclose(io); \
      |             ^~~~~~~~~~
/home/kratz00/coding/mojosetup/misc/make_self_extracting.c:78:9: note: in expansion of macro 'FAIL'
   78 |         FAIL("fclose");
      |         ^~~~
/home/kratz00/coding/mojosetup/misc/make_self_extracting.c:77:14: note: call to 'fclose' here
   77 |     else if (fclose(io) == EOF)
```
