### PR TITLE
GitHub Actions: Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install cmake ninja-build libgtk2.0-dev libgtk-3-dev libncursesw5-dev
     - name: Get mojosetup sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Configure CMake
       run: cmake -B build ${{ matrix.platform.flags }}
     - name: Build


### PR DESCRIPTION
Node.js 12 actions are deprecated.
Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.