### PR TITLE
Support compiling on aarch64 (Raspberry Pi 64-bit).

### DIFF
--- a/platform.h
+++ b/platform.h
@@ -352,6 +352,8 @@ uint64 MojoPlatform_getgid(void);
 #define PLATFORM_ARCH "x86-64"
 #elif defined(__X86__) || defined(__i386__) || defined(i386) || defined (_M_IX86) || defined(__386__)
 #define PLATFORM_ARCH "x86"
+#elif defined(__aarch64__)
+#define PLATFORM_ARCH "aarch64"
 #elif defined(__arm__) && defined(__ARM_PCS_VFP)
 #define PLATFORM_ARCH "armhf"
 #else


### PR DESCRIPTION
Raspberry Pi 64-bit is AArch64, and without this patch, MojoSetup cannot compile on it.
With the architecture defined, MojoSetup works just fine.